### PR TITLE
Add SuggestIT to available services

### DIFF
--- a/frontend/src/service.json
+++ b/frontend/src/service.json
@@ -133,5 +133,14 @@
         "description": "If there's anything you don't know how to do, you might find it here.",
         "github_url": "https://github.com/cthit/HowTo",
         "fontawesome_icon": "fa-question-circle"
+    },
+
+
+    {
+        "title": "SuggestIT",
+        "url": "https://suggestit.chalmers.it",
+        "description": "Submit suggestions for Hubben 2.1 or the IT student division.",
+        "github_url": "https://github.com/cthit/SuggestIT",
+        "fontawesome_icon": "fa-lightbulb-o"
     }
 ]


### PR DESCRIPTION
Fixes #27 

Maybe there is a better icon available than the light bulb, but I think it represents an idea well enough. We could change the HueIT icon if we want to avoid duplicates.